### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fastlane-build.yaml
+++ b/.github/workflows/fastlane-build.yaml
@@ -3,6 +3,9 @@ name: Fastlane build
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Release binary and push it to AppStore


### PR DESCRIPTION
Potential fix for [https://github.com/novalagung/kalenderpuasa-ios/security/code-scanning/1](https://github.com/novalagung/kalenderpuasa-ios/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/fastlane-build.yaml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
Best minimal non-breaking change here is:

- `permissions:`
  - `contents: read`

This aligns with CodeQL’s suggested minimum and does not change workflow logic beyond tightening token access. Place it right after the `on:` block (or before `jobs:`), so the `deploy` job inherits it automatically. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
